### PR TITLE
feat: block hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ dependencies = [
  "anyhow",
  "astria-core",
  "astria-eyre",
+ "astria-merkle",
  "astria-sequencer",
  "astria-sequencer-client",
  "astria-telemetry",

--- a/chat-rollup/Cargo.toml
+++ b/chat-rollup/Cargo.toml
@@ -27,6 +27,7 @@ astria-core = { git = "https://github.com/astriaorg/astria.git", package = "astr
   "test-utils",
 
 ] }
+merkle = { git = "https://github.com/astriaorg/astria.git", package = "astria-merkle" }
 tower-abci = "0.12.0"
 astria-eyre = { git = "https://github.com/astriaorg/astria.git", package = "astria-eyre", features = [
   "anyhow",

--- a/chat-rollup/src/lib.rs
+++ b/chat-rollup/src/lib.rs
@@ -7,5 +7,4 @@ pub mod rollup;
 pub mod snapshot;
 pub mod storage;
 pub mod text;
-
 pub use config::Config;


### PR DESCRIPTION
The block hash being set in the rollup is hard coded, an hash of sort is important for a proper rollup to operate. This PR introduces naive sequential hashing of `transactions`, `prev_block_hash` and `timestamp`. 
Note: In the future, transaction and deposits should be stored in a verifiable merkle tree and state hash should be taken into consideration. 
- calculates and stores block hash
- implements `batch_get_blocks`