### PR TITLE
Reduce resource requirements

### DIFF
--- a/charts/deploy.just
+++ b/charts/deploy.just
@@ -70,8 +70,8 @@ deploy-novm-chat-rollup:
 delete-astria-chat:
   @just delete chart astria-chat
 
-deploy-astria-local namespace=defaultNamespace: (helm-add-if-not-exist "astria" "https://astriaorg.github.io/charts/")(deploy-celestia-local namespace) (deploy-sequencer)
-delete-astria-local namespace=defaultNamespace: (delete-chart "celestia-local" namespace) (delete-sequencer)
+deploy-astria-local namespace=defaultNamespace: (helm-add-if-not-exist "astria" "https://astriaorg.github.io/charts/") (deploy-sequencer)
+delete-astria-local namespace=defaultNamespace: (delete-sequencer)
 
 deploy-astria-chat namespace=defaultNamespace: (deploy-cluster) (deploy-ingress-controller) (wait-for-ingress-controller) (deploy-astria-local) (install-frontend) (build-and-load-frontend) (deploy-novm-chat-rollup) (wait-for-astria-chat)
 

--- a/dev/values/rollup/chat-dev.yaml
+++ b/dev/values/rollup/chat-dev.yaml
@@ -13,7 +13,7 @@ config:
     # - "SoftOnly" -> blocks are only pulled from the sequencer
     # - "FirmOnly" -> blocks are only pulled from DA
     # - "SoftAndFirm" -> blocks are pulled from both the sequencer and DA
-    executionCommitLevel: 'SoftAndFirm'
+    executionCommitLevel: 'SoftOnly'
     # The expected fastest block time possible from sequencer, determines polling
     # rate.
     sequencerBlockTimeMs: 2000
@@ -37,11 +37,18 @@ config:
 resources:
   conductor:
     requests:
-      cpu: 1
+      cpu: 100m
       memory: 100Mi
     limits:
       cpu: 2
       memory: 500Mi
+  chat:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 2
+      memory: 1Gi
 
 storage:
   enabled: false
@@ -67,4 +74,3 @@ composer:
         filename: "key.hex"
         resourceName: "projects/$PROJECT_ID/secrets/sequencerPrivateKey/versions/latest"
     rollups: []
-


### PR DESCRIPTION
1. Reduce resource requirements of conductor which is also used by chat frontend
2. Remove celestia-local chart from `just deploy-astria-local`
3. Set rollup conductor to use `SoftOnly` to work with (2)

This reduces the resource `Requests` on the `kind` cluster from
```
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests      Limits
  --------           --------      ------
  cpu                5450m (90%)   11 (183%)
  memory             5662Mi (17%)  12240Mi (38%)
```
to
```
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests     Limits
  --------           --------     ------
  cpu                2650m (44%)  9 (150%)
  memory             1566Mi (4%)  4048Mi (12%)
  ```